### PR TITLE
Process Doc Update]: Add README for docs/ - summary of project management processes and links to all docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# OctoAcme Project Management Docs
+
+Welcome! This directory contains living documentation for OctoAcme’s project management approaches, roles, and workflows. Use this README as your entry point to understand processes, find templates, and onboard quickly.
+
+## Overview: OctoAcme Project Management Processes
+
+OctoAcme projects follow a clear lifecycle from Initiation through Planning, Execution, Release, and Retrospective. Projects begin by clarifying the problem, goals, metrics for success, and key stakeholders using a Project One-pager. Only once outcomes, priorities, and team capacity are confirmed does work advance to Planning, where initiatives are broken into actionable backlogs, with estimates, a Definition of Done, and a risk register. 
+
+Execution is managed on a standardized board (Backlog → Ready → In Progress → In Review → QA → Done) with an emphasis on small PRs, strong acceptance criteria, test automation, and manual QA when needed. Release and deployment are guided by pre-release checklists, automated pipelines, post-deploy verifications, and thorough incident/rollback plans. Each project closes with a retrospective: learnings and action items are captured and fed back into team practice.
+
+Roles and communication strategies are explicit: Product Managers define outcomes, Project Managers coordinate execution and risk, Developers implement and test, and QA verifies quality. Cadences include daily standups, weekly syncs, and regular stakeholder updates. Risk management, escalation paths, and communication templates support transparency and alignment. Continuous improvement is part of the culture, with retrospective-derived actions tracked in the backlog.
+
+## Docs Index
+
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](octoacme-roles-and-personas.md)
+
+---
+
+Keep this README up to date as the first stop for new contributors, and use it to navigate the full OctoAcme program management playbook.


### PR DESCRIPTION
Adds docs/README.md as a landing page summarizing OctoAcme project management processes and linking to all process documents.
Refs #2